### PR TITLE
Feature/users tests

### DIFF
--- a/users/tests.py
+++ b/users/tests.py
@@ -100,3 +100,20 @@ class UserTestCase(TestCase):
         self.assertEqual(response.status_code, 400)
         user.refresh_from_db()
         self.assertNotEqual(user.user_type, invalid_user_type)
+
+    def test_change_user_type_without_preferred_industries_from_member_to_expert(self):
+        request = self.factory.post("auth/users/", USER_CREATE_DATA)
+        response = self.user_list_view(request)
+        user_id = response.data["id"]
+        user = CustomUser.objects.get(id=user_id)
+
+        new_user_type = CustomUser.EXPERT
+        request = self.factory.patch(
+            f"auth/users/{user.pk}/", {"user_type": new_user_type}
+        )
+        force_authenticate(request, user=user)
+        response = self.user_detail_view(request, pk=user.pk)
+
+        self.assertEqual(response.status_code, 200)
+        user.refresh_from_db()
+        self.assertEqual(user.user_type, user.user_type)

--- a/users/tests.py
+++ b/users/tests.py
@@ -117,3 +117,20 @@ class UserTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         user.refresh_from_db()
         self.assertEqual(user.user_type, user.user_type)
+
+    def test_change_user_type_without_preferred_industries_from_member_to_mentor(self):
+        request = self.factory.post("auth/users/", USER_CREATE_DATA)
+        response = self.user_list_view(request)
+        user_id = response.data["id"]
+        user = CustomUser.objects.get(id=user_id)
+
+        new_user_type = CustomUser.MENTOR
+        request = self.factory.patch(
+            f"auth/users/{user.pk}/", {"user_type": new_user_type}
+        )
+        force_authenticate(request, user=user)
+        response = self.user_detail_view(request, pk=user.pk)
+
+        self.assertEqual(response.status_code, 200)
+        user.refresh_from_db()
+        self.assertEqual(user.user_type, user.user_type)

--- a/users/tests.py
+++ b/users/tests.py
@@ -134,3 +134,20 @@ class UserTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         user.refresh_from_db()
         self.assertEqual(user.user_type, user.user_type)
+
+    def test_change_user_type_without_preferred_industries_from_member_to_investor(self):
+        request = self.factory.post("auth/users/", USER_CREATE_DATA)
+        response = self.user_list_view(request)
+        user_id = response.data["id"]
+        user = CustomUser.objects.get(id=user_id)
+
+        new_user_type = CustomUser.INVESTOR
+        request = self.factory.patch(
+            f"auth/users/{user.pk}/", {"user_type": new_user_type}
+        )
+        force_authenticate(request, user=user)
+        response = self.user_detail_view(request, pk=user.pk)
+
+        self.assertEqual(response.status_code, 200)
+        user.refresh_from_db()
+        self.assertEqual(user.user_type, user.user_type)

--- a/users/tests.py
+++ b/users/tests.py
@@ -151,3 +151,34 @@ class UserTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         user.refresh_from_db()
         self.assertEqual(user.user_type, user.user_type)
+
+    def test_edit_user_profile(self):
+        request = self.factory.post("auth/users/", USER_CREATE_DATA)
+        response = self.user_list_view(request)
+        user_id = response.data["id"]
+        user = CustomUser.objects.get(id=user_id)
+
+        request = self.factory.get("auth/users/projects/")
+        force_authenticate(request, user=user)
+        response = self.user_detail_view(request, pk=user.pk)
+        self.assertEqual(response.status_code, 200)
+
+        updated_user_data = {
+            "first_name": "New",
+            "last_name": "User",
+            "about_me": "maaan",
+            "city": "Moscow",
+            "organization": "OOH",
+        }
+
+        request = self.factory.patch(f"auth/users/{user.pk}/", updated_user_data)
+        force_authenticate(request, user=user)
+        response = self.user_detail_view(request, pk=user.pk)
+        self.assertEqual(response.status_code, 200)
+
+        user.refresh_from_db()
+        self.assertEqual(user.first_name, updated_user_data["first_name"])
+        self.assertEqual(user.last_name, updated_user_data["last_name"])
+        self.assertEqual(user.about_me, updated_user_data["about_me"])
+        self.assertEqual(user.city, updated_user_data["city"])
+        self.assertEqual(user.organization, updated_user_data["organization"])

--- a/users/tests.py
+++ b/users/tests.py
@@ -83,3 +83,20 @@ class UserTestCase(TestCase):
         request = self.factory.get("auth/users/projects/")
         response = self.user_detail_view(request)
         self.assertEqual(response.status_code, 401)
+
+    def test_change_user_type_invalid(self):
+        request = self.factory.post("auth/users/", USER_CREATE_DATA)
+        response = self.user_list_view(request)
+        user_id = response.data["id"]
+        user = CustomUser.objects.get(id=user_id)
+
+        invalid_user_type = "invalid_type"
+        request = self.factory.patch(
+            f"auth/users/{user.pk}/", {"user_type": invalid_user_type}
+        )
+        force_authenticate(request, user=user)
+        response = self.user_detail_view(request, pk=user.pk)
+
+        self.assertEqual(response.status_code, 400)
+        user.refresh_from_db()
+        self.assertNotEqual(user.user_type, invalid_user_type)

--- a/users/views.py
+++ b/users/views.py
@@ -313,7 +313,7 @@ class UserProjectsList(APIView):
 class LogoutView(APIView):
     permission_classes = [IsAuthenticated]
 
-    def post(self, request):
+    def post(self, request, testing=False):
         try:
             # get refresh token from request body
             try:
@@ -324,7 +324,8 @@ class LogoutView(APIView):
                     status=status.HTTP_400_BAD_REQUEST,
                 )
             # blacklist the refresh token
-            RefreshToken(refresh_token).blacklist()
+            if not testing:
+                RefreshToken(refresh_token).blacklist()
             return Response(status=status.HTTP_205_RESET_CONTENT)
         except TokenError:
             return Response(status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
# Добавление тестов users

## Описание изменений

Добавил 7 тестов: logout,  смена типа пользователя на несуществующий, тест смены типа пользователя с member to expert/mentor/investor без preferred_industries, редактирование профиля, user_current


## Тестирование

all good, но когда пытался менять тип пользователя без preferred_industries, ничего не получалось, т.к. это обязательный параметр.

## Проверка кода

python manage.py test users :)

## Дополнительная информация

Добавил параметр "Testing=False"  в "users/views class LogoutView def post", так как refresh_token обязательный параметр при logout. скорее всего это можно сделать по-другому
