### PR TITLE
change accompanying file type in serializers

### DIFF
--- a/vacancy/managers.py
+++ b/vacancy/managers.py
@@ -45,13 +45,6 @@ class VacancyResponseManager(Manager):
                 "vacancy__project__leader",
                 "accompanying_file",
             )
-            .only(
-                "user__id",
-                "vacancy__id",
-                "why_me",
-                "accompanying_file",
-                "is_approved",
-            )
         )
 
     def get_vacancy_response_for_email(self):

--- a/vacancy/serializers.py
+++ b/vacancy/serializers.py
@@ -4,7 +4,7 @@ from rest_framework import serializers
 
 from core.models import Skill, SkillToObject
 from core.serializers import SkillToObjectSerializer
-from files.serializers import UserFileSerializer
+from files.models import UserFile
 from projects.models import Project
 from users.serializers import UserDetailSerializer
 from vacancy.models import Vacancy, VacancyResponse
@@ -134,7 +134,12 @@ class VacancyResponseListSerializer(serializers.ModelSerializer[VacancyResponse]
     is_approved = serializers.BooleanField(read_only=True)
     user = UserDetailSerializer(read_only=True)
     user_id = serializers.IntegerField(write_only=True)
-    accompanying_file = UserFileSerializer(required=False, allow_null=True)
+    accompanying_file = serializers.SlugRelatedField(
+        slug_field="link",
+        queryset=UserFile.objects.all(),
+        required=False,
+        allow_null=True,
+    )
 
     class Meta:
         model = VacancyResponse
@@ -177,7 +182,12 @@ class VacancyResponseDetailSerializer(serializers.ModelSerializer[VacancyRespons
     user = UserDetailSerializer(many=False, read_only=True)
     vacancy = VacancyListSerializer(many=False, read_only=True)
     is_approved = serializers.BooleanField(read_only=True)
-    accompanying_file = UserFileSerializer(required=False, allow_null=True)
+    accompanying_file = serializers.SlugRelatedField(
+        slug_field="link",
+        queryset=UserFile.objects.all(),
+        required=False,
+        allow_null=True,
+    )
 
     class Meta:
         model = VacancyResponse


### PR DESCRIPTION
1. Changed accompanying_file type in serializers to `SlugRelatedField`
2. Deleted `only` method, bc causes conflicts:  
Cannot be both deferred and traversed using select_related at the same time.


