### PR TITLE
PRO-463: Permission for projects in programs | Tag deletion bug

### DIFF
--- a/partner_programs/admin.py
+++ b/partner_programs/admin.py
@@ -235,3 +235,9 @@ class PartnerProgramUserProfileAdmin(admin.ModelAdmin):
     )
     search_fields = ("user__first_name", "user__last_name", "partner_program_data")
     date_hierarchy = "datetime_created"
+
+    def get_form(self, request, obj=None, **kwargs):
+        """`partner_program` field is optional in admin panel (bc is nullable)."""
+        form = super().get_form(request, obj, **kwargs)
+        form.base_fields["project"].required = False
+        return form

--- a/projects/views.py
+++ b/projects/views.py
@@ -33,6 +33,7 @@ from projects.permissions import (
     HasInvolvementInProjectOrReadOnly,
     IsProjectLeader,
     IsNewsAuthorIsProjectLeaderOrReadOnly,
+    TimingAfterEndsProgramPermission,
 )
 from projects.serializers import (
     ProjectDetailSerializer,
@@ -129,7 +130,7 @@ class ProjectList(generics.ListCreateAPIView):
 
 class ProjectDetail(generics.RetrieveUpdateDestroyAPIView):
     queryset = Project.objects.get_projects_for_detail_view()
-    permission_classes = [HasInvolvementInProjectOrReadOnly]
+    permission_classes = [HasInvolvementInProjectOrReadOnly, TimingAfterEndsProgramPermission]
     serializer_class = ProjectDetailSerializer
 
     def retrieve(self, request, *args, **kwargs):


### PR DESCRIPTION
1.Ограничение редактирования проекта, состоящего в завершенной программе:
На (редактирование/удаление) навешен permission запрещающий взаимодействие с проектом до истечения тайминга. Текущий тайминг = 30 дней.
При попытке редактировать/удалить программу возникает исключение, response следующий: 
Код: 403
body:
```
{
    "program_name": "Наименование программы",
    "when_can_edit": "2024-10-30 20:59:59+03:00",
    "days_until_resolution": "29"
}
```
Где:
program_name: str -> Наименование программы.
when_can_edit: datetime(str) -> Московская дата-время когда будет доступ (с точностью до секунд). 
days_until_resolution: str(int) -> Дней до возможности редактировать.

2.Баг - невозможно отвязать проект от программы:
Исправлен, пользователь может отвязать проект от программы, разные кейсы: 
-Программа, к которой привязан проект, завершена, при этом тайминг не прошел (П.1) не получится отвязать.
-Программа, к которой привязан проект, завершена, при этом тайминг не прошел (П.1) отвязать получится, не получится привязать обратно (завершена). 
-Проект не привязан к программе, выбрать получится только те программы, где юзер участник и программа не завершена. 
-Отвязать от любой не завершенной программы можно без проблем. 
-Обвязать от любой завершенной программы можно только через месяц. 
В случае возникновения исключения в рамках выбора завершенной программы, в response будет выбрасываться: 
Код: 400
```
{
    "error": "Cannot select a completed program."
}
```

Бек подстроент под запрос с фронта - если пользователь выбирает "Без тега" получаем `partner_program_id: int = 0`, что означает отвязку. 
С одной стороны, ожидаемое значение - null, но тогда возникнет проблема с PATCH запросом(пришлось бы лезть в логику view), в принципе 0 тоже уместно, т.к. id PK равный нулю не может существовать (ограничение БД в целом).
