### PR TITLE
PRO-472: User skill quantity validation

### DIFF
--- a/users/constants.py
+++ b/users/constants.py
@@ -73,9 +73,13 @@ class UserEducationStatuses(Enum):
 
 USER_EXPERIENCE_YEAR_VALIDATION_MESSAGE: str = "Год начала не может быть больше года завершения"
 
+# Working with user skills:
+USER_MAX_SKILL_QUANTITY: int = 20
+USER_SKILL_QUANTITY_VALIDATIONS_MESSAGE: str = "Необходимо указать от 1 до 20 навыков"
+
 # Working with user languages:
 USER_MAX_LANGUAGES_COUNT: int = 4
-COUNT_LANGUAGES_VALIDATION_MESSAGE: str = "Пользователь не может указать более 4 языков."
+COUNT_LANGUAGES_VALIDATION_MESSAGE: str = "Пользователь не может указать более 4 языков"
 UNIQUE_LANGUAGES_VALIDATION_MESSAGE: str = "Нельзя добавлять дубликаты языков"
 
 


### PR DESCRIPTION
Пользователь ограничен по кол-ву выбранных навыков: от 1 до 20 (включительно). 
Ограничение только на уровне API запросов, на уровне БД валидация не применяется осознанно, т.к. может понадобиться внести правки в профиль пользователя(у которого более 20 навыков уже выбрано) мануально.

Текущее ограничение работает след. образом:
Если с фронта отправлено поле "skills_ids" (значит вносятся правки в навыки):
- Валиадируется направленное кол-во (1-20)
- Валидируются id-шники (на наличие такого навыка)
- Устанавливаются новые навыки

Если пользователь(с кол-вом навыков > 20) обновляет профиль, но при этом не трогал навыки (соотв. в payload не будет "skills_ids"), то любые редактирования профиля будут недоступны, пока не уберет "лишние" навыки.
