### PR TITLE
Исправлена версия actions/cache@v4 в workflows

### DIFF
--- a/.github/workflows/django-test.yml
+++ b/.github/workflows/django-test.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: 3.11
 
       - name: cache poetry install
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.local
           key: poetry-1.2.2-0
@@ -32,7 +32,7 @@ jobs:
 
       - name: cache deps
         id: cache-deps
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .venv
           key: pydeps-${{ hashFiles('**/poetry.lock') }}

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -18,7 +18,7 @@ jobs:
           python-version: 3.11
 
       - name: cache poetry install
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.local
           key: poetry-1.2.2-0
@@ -31,7 +31,7 @@ jobs:
 
       - name: cache deps
         id: cache-deps
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .venv
           key: pydeps-${{ hashFiles('**/poetry.lock') }}


### PR DESCRIPTION
# Исправлена версия actions/cache@v4 в workflows

## Описание изменений

_В связи с тем что, версия cache_v2 c декабря 2024 года больше не поддерживается исправлено на актуальную версию._

