### PR TITLE
Добавлены уровни доступов для Invites

### DIFF
--- a/projects/permissions.py
+++ b/projects/permissions.py
@@ -1,12 +1,11 @@
-from datetime import timedelta, datetime
+from datetime import datetime, timedelta
 
 from django.utils import timezone
+from rest_framework.exceptions import PermissionDenied, ValidationError
+from rest_framework.permissions import SAFE_METHODS, BasePermission
 
-from rest_framework.permissions import BasePermission, SAFE_METHODS
-from rest_framework.exceptions import PermissionDenied
-
+from partner_programs.models import PartnerProgram, PartnerProgramUserProfile
 from projects.models import Project
-from partner_programs.models import PartnerProgramUserProfile
 
 
 class IsProjectLeaderOrReadOnlyForNonDrafts(BasePermission):
@@ -79,6 +78,7 @@ class TimingAfterEndsProgramPermission(BasePermission):
     for `_SECONDS_AFTER_CANT_EDIT` seconds -> days from the end of the program.
     If the project is not in program or the request in `SAFE_METHODS` -> allowed.
     """
+
     _SECONDS_AFTER_CANT_EDIT: int = 60 * 60 * 24 * 30  # Now 30 days.
 
     def has_object_permission(self, request, view, obj) -> bool:
@@ -86,22 +86,29 @@ class TimingAfterEndsProgramPermission(BasePermission):
             return True
 
         program_profile = (
-            PartnerProgramUserProfile.objects
-            .filter(user=request.user, project=obj)
+            PartnerProgramUserProfile.objects.filter(user=request.user, project=obj)
             .select_related("partner_program")
             .first()
         )
         moscow_time: datetime = timezone.localtime(timezone.now())
 
         if program_profile:
-            date_from_end_program: timedelta = (moscow_time - program_profile.partner_program.datetime_finished)
+            date_from_end_program: timedelta = (
+                moscow_time - program_profile.partner_program.datetime_finished
+            )
             days_from_end_program: int = date_from_end_program.days
             seconds_from_end_program: int = date_from_end_program.total_seconds()
             if 0 <= seconds_from_end_program <= self._SECONDS_AFTER_CANT_EDIT:
-                raise PermissionDenied(detail=self._prepare_exception_detail(days_from_end_program, program_profile))
+                raise PermissionDenied(
+                    detail=self._prepare_exception_detail(
+                        days_from_end_program, program_profile
+                    )
+                )
         return True
 
-    def _prepare_exception_detail(self, days_from_end_program: int, program_profile: PartnerProgramUserProfile):
+    def _prepare_exception_detail(
+        self, days_from_end_program: int, program_profile: PartnerProgramUserProfile
+    ):
         """
         Prepare response body when `PermissionDenied` exception raised:
             program_name: str -> Program title
@@ -112,7 +119,11 @@ class TimingAfterEndsProgramPermission(BasePermission):
         when_can_edit: datetime = timezone.localtime(
             datetime_finished + timedelta(seconds=self._SECONDS_AFTER_CANT_EDIT)
         )
-        days_until_resolution: int = int(self._SECONDS_AFTER_CANT_EDIT / 60 / 60 / 24) - days_from_end_program - 1
+        days_until_resolution: int = (
+            int(self._SECONDS_AFTER_CANT_EDIT / 60 / 60 / 24)
+            - days_from_end_program
+            - 1
+        )
         return {
             "program_name": program_profile.partner_program.name,
             "when_can_edit": when_can_edit,
@@ -140,3 +151,24 @@ class IsNewsAuthorIsProjectLeaderOrReadOnly(BasePermission):
         ) or obj.project.leader == request.user:
             return True
         return False
+
+
+class CanBindProjectToProgram(BasePermission):
+    message = "Привязать проект к программе может только её участник (или менеджер)."
+
+    def has_permission(self, request, view):
+        program_id = (request.data or {}).get("partner_program_id")
+        if not program_id:
+            return True
+
+        try:
+            program = PartnerProgram.objects.get(pk=program_id)
+        except PartnerProgram.DoesNotExist:
+            raise ValidationError({"partner_program_id": "Программа не найдена."})
+
+        if program.is_manager(request.user):
+            return True
+
+        return PartnerProgramUserProfile.objects.filter(
+            user=request.user, partner_program=program
+        ).exists()

--- a/projects/serializers.py
+++ b/projects/serializers.py
@@ -387,7 +387,7 @@ class ProjectDuplicateRequestSerializer(serializers.Serializer):
 
         if project.leader != request.user:
             raise serializers.ValidationError(
-                "Только лидер проекта может дублировать его в программу."
+                {"error": "Только лидер проекта может дублировать его в программу."}
             )
 
         try:

--- a/projects/views.py
+++ b/projects/views.py
@@ -33,6 +33,7 @@ from projects.helpers import (
 from projects.models import Achievement, Collaborator, Project, ProjectNews
 from projects.pagination import ProjectNewsPagination, ProjectsPagination
 from projects.permissions import (
+    CanBindProjectToProgram,
     HasInvolvementInProjectOrReadOnly,
     IsNewsAuthorIsProjectLeaderOrReadOnly,
     IsProjectLeader,
@@ -659,7 +660,7 @@ class SwitchLeaderRole(generics.GenericAPIView):
 
 
 class DuplicateProjectView(APIView):
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsAuthenticated, CanBindProjectToProgram]
 
     @swagger_auto_schema(
         request_body=ProjectDuplicateRequestSerializer,


### PR DESCRIPTION
# Добавлены проверки при приглашении в проекта, а также при попытке подать проект на программу. 

## Описание изменений

1. В проект нельзя пригласить лидера проекта;
2. В проект нельзя пригласить участника проекта;
3. Если у пользователя уже есть приглашение, то ему нельзя выслать новое в тот же проект;
4. Если проект связан с программой, то нельзя пригласить пользователя, который в ней не состоит;
5. В проект может пригласить только лидер проекта.


Запрос к ручке projects/assign-to-program/ смогут использовать только участники или менеджеры программы.
