### PR TITLE
Devops structure rework

### DIFF
--- a/users/serializers.py
+++ b/users/serializers.py
@@ -378,6 +378,7 @@ class UserSubscribedProjectsSerializer(serializers.ModelSerializer[Project]):
         ]
         read_only_fields = ["leader", "collaborator", "is_company"]
 
+
 class UserExperienceMixin:
     """Mixin for Education and WorkExperience with same logic."""
 

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -378,22 +378,6 @@ class UserSubscribedProjectsSerializer(serializers.ModelSerializer[Project]):
         ]
         read_only_fields = ["leader", "collaborator", "is_company"]
 
-
-class SubscriptionSerializer(serializers.Serializer):
-    id = serializers.IntegerField()
-    name = serializers.CharField()
-    price = serializers.IntegerField()
-    features_list = serializers.ListField(child=serializers.CharField())
-
-
-class UserSubscriptionDataSerializer(serializers.Serializer):
-    is_subscribed = serializers.BooleanField()
-    last_subscription_date = serializers.CharField()
-    subscription_date_over = serializers.CharField()
-    last_subscription_type = SubscriptionSerializer()
-    is_autopay_allowed = serializers.BooleanField()
-
-
 class UserExperienceMixin:
     """Mixin for Education and WorkExperience with same logic."""
 
@@ -991,12 +975,6 @@ class UserProjectListSerializer(serializers.ModelSerializer[Project]):
         return validate_project(data)
 
 
-class UserCloneDataSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = CustomUser
-        fields = "__all__"
-
-
 class CustomObtainPairSerializer(TokenObtainPairSerializer):
     def validate(self, attrs):
         data = super().validate(attrs)
@@ -1008,8 +986,3 @@ class CustomObtainPairSerializer(TokenObtainPairSerializer):
         token = super().get_token(user)
         token["email"] = user.email
         return token
-
-
-class RemoteBuySubSerializer(serializers.Serializer):
-    subscription_id = serializers.IntegerField()
-    redirect_url = serializers.CharField(required=False)

--- a/users/tests.py
+++ b/users/tests.py
@@ -4,7 +4,8 @@ from tests.constants import USER_CREATE_DATA
 
 from projects.models import Collaborator, Project
 from users.models import CustomUser
-from users.views import UserLeaderProjectsList, UserList, UserDetail
+from users.serializers import UserDetailSerializer
+from users.views import CurrentUser, UserLeaderProjectsList, UserList, UserDetail
 
 
 class UserTestCase(TestCase):
@@ -13,6 +14,7 @@ class UserTestCase(TestCase):
         self.user_list_view = UserList.as_view()
         self.user_detail_view = UserDetail.as_view()
         self.user_leader_projects_view = UserLeaderProjectsList.as_view()
+        self.current_user_view = CurrentUser.as_view()
 
     def test_user_creation(self):
         request = self.factory.post("auth/users/", USER_CREATE_DATA)
@@ -82,6 +84,22 @@ class UserTestCase(TestCase):
         self.assertSetEqual(
             returned_ids, {leader_project.id, second_leader_project.id}
         )
+
+    def test_current_user_returns_authenticated_user_profile(self):
+        user = self._user_create("current@example.com")
+
+        request = self.factory.get("auth/users/current/")
+        force_authenticate(request, user=user)
+        response = self.current_user_view(request)
+        expected_data = UserDetailSerializer(user, context={"request": request}).data
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, expected_data)
+
+    def test_removed_legacy_routes_return_404(self):
+        self.assertEqual(self.client.get("/auth/users/clone-data").status_code, 404)
+        self.assertEqual(self.client.get("/auth/subscription/").status_code, 404)
+        self.assertEqual(self.client.post("/auth/subscription/buy/").status_code, 404)
 
     def _user_create(self, email):
         tmp_create_data = USER_CREATE_DATA.copy()

--- a/users/urls.py
+++ b/users/urls.py
@@ -26,9 +26,6 @@ from users.views import (
     UserSpecializationsNestedView,
     UserSpecializationsInlineView,
     UserSkillsApproveDeclineView,
-    SingleUserDataView,
-    RemoteViewSubscriptions,
-    RemoteCreatePayment,
     UserCVDownload,
     UserCVMailing,
 )
@@ -86,9 +83,4 @@ urlpatterns = [
         "reset_password/",
         include("django_rest_passwordreset.urls", namespace="password_reset"),
     ),
-    # for skills
-    path("users/clone-data", SingleUserDataView.as_view()),
-    # copy from skills
-    path("subscription/", RemoteViewSubscriptions.as_view()),
-    path("subscription/buy/", RemoteCreatePayment.as_view()),
 ]

--- a/users/views.py
+++ b/users/views.py
@@ -1,7 +1,6 @@
 import urllib.parse
 
 import jwt
-import requests
 from django.apps import apps
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -54,18 +53,15 @@ from users.serializers import (
     AchievementDetailSerializer,
     AchievementListSerializer,
     PublicUserSerializer,
-    RemoteBuySubSerializer,
     ResendVerifyEmailSerializer,
     SpecializationSerializer,
     SpecializationsSerializer,
     UserApproveSkillResponse,
-    UserCloneDataSerializer,
     UserDetailSerializer,
     UserListSerializer,
     UserProjectListSerializer,
     UserSkillConfirmationSerializer,
     UserSubscribedProjectsSerializer,
-    UserSubscriptionDataSerializer,
     VerifyEmailSerializer,
 )
 from users.typing import UserCVDataV2
@@ -261,31 +257,7 @@ class CurrentUser(GenericAPIView):
     def get(self, request):
         user = request.user
         serializer = self.get_serializer(user)
-
-        if settings.DEBUG:
-            skills_url_name = (
-                "https://skills.dev.procollab.ru/progress/subscription-data/"
-            )
-        else:
-            skills_url_name = (
-                "https://api.skills.procollab.ru/progress/subscription-data/"
-            )
-        try:
-            subscription_data = requests.get(
-                skills_url_name,
-                headers={
-                    "accept": "application/json",
-                    "Authorization": request.META.get("HTTP_AUTHORIZATION"),
-                },
-            )
-            subscription_serializer = UserSubscriptionDataSerializer(
-                subscription_data.json()
-            )
-            subs_data = subscription_serializer.data
-        except Exception:
-            subs_data = {}
-
-        return Response(serializer.data | subs_data, status=status.HTTP_200_OK)
+        return Response(serializer.data, status=status.HTTP_200_OK)
 
 
 class UserTypesView(APIView):
@@ -573,82 +545,6 @@ class UserSpecializationsInlineView(ListAPIView):
 
     def get_queryset(self):
         return Specialization.objects.all()
-
-
-class SingleUserDataView(ListAPIView):
-    serializer_class = UserCloneDataSerializer
-    permissions = [AllowAny]
-    authentication_off = True
-
-    def get_queryset(self) -> User:
-        return [get_object_or_404(User, email=self.request.data["email"])]
-
-
-class RemoteViewSubscriptions(APIView):
-    permission_classes = [AllowAny]
-
-    def get(self, request, *args, **kwargs):
-        try:
-            subscriptions = self._get_response_from_remote_api()
-            return Response(subscriptions, status=status.HTTP_200_OK)
-        except requests.RequestException as e:
-            return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
-
-    def _get_link_to_remote_api(self) -> str:
-        # TODO something to reuse this code
-        if settings.DEBUG:
-            subscriptions_url = "https://skills.dev.procollab.ru/subscription/"
-        else:
-            subscriptions_url = "https://api.skills.procollab.ru/subscription/"
-        return subscriptions_url
-
-    def _get_response_from_remote_api(self):
-        subscriptions_url = self._get_link_to_remote_api()
-        response = requests.get(
-            subscriptions_url,
-            headers={
-                "accept": "application/json",
-                "Authorization": self.request.META.get("HTTP_AUTHORIZATION"),
-            },
-        )
-        response.raise_for_status()
-        return response.json()
-
-
-class RemoteCreatePayment(GenericAPIView):
-    serializer_class = RemoteBuySubSerializer
-    permission_classes = [AllowAny]
-
-    def post(self, request, *args, **kwargs):
-        try:
-            subscriptions_buy_url = self._get_link_to_remote_api()
-            data, headers = self._get_data_to_request_remote_api()
-            response = requests.post(subscriptions_buy_url, json=data, headers=headers)
-            response.raise_for_status()
-            return Response(response.json(), status=status.HTTP_200_OK)
-        except requests.RequestException as e:
-            return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
-
-    def _get_link_to_remote_api(self) -> str:
-        # TODO something to reuse this code
-        if settings.DEBUG:
-            subscriptions_buy_url = "https://skills.dev.procollab.ru/subscription/buy/"
-        else:
-            subscriptions_buy_url = "https://api.skills.procollab.ru/subscription/buy/"
-        return subscriptions_buy_url
-
-    def _get_data_to_request_remote_api(self) -> tuple[dict, dict]:
-        serializer = self.serializer_class(data=self.request.data)
-        if serializer.is_valid():
-            data = serializer.validated_data
-            headers = {
-                "accept": "application/json",
-                "Authorization": self.request.META.get("HTTP_AUTHORIZATION"),
-            }
-            return data, headers
-
-        else:
-            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
 class UserCVDownload(APIView):


### PR DESCRIPTION
# Удаление legacy skills integration из users API

## Описание изменений

В `users`-части основного API удалена legacy-интеграция с сервисом `skills`, которая больше не нужна для `dev` и мешает дальнейшему выводу `skills` с сервера.

Что изменено:
- удалены legacy-routes:
  - `/auth/users/clone-data`
  - `/auth/subscription/`
  - `/auth/subscription/buy/`
- удалены связанные view и serializer-классы, которые использовались только для интеграции со `skills`
- `CurrentUser` больше не делает внешний запрос в `skills` и теперь возвращает только локальный профиль пользователя через `UserDetailSerializer`
- добавлены/обновлены тесты:
  - `CurrentUser` возвращает корректный профиль текущего пользователя
  - удалённые legacy-routes возвращают `404`
- отдельным follow-up коммитом исправлено замечание `flake8` в `users/serializers.py`

