### PR TITLE
Унифицирован deploy dev/prod и подготовлен prod host nginx

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -18,30 +18,38 @@ jobs:
             username: ${{ secrets.DEV_SERVER_USER }}
             password: ${{ secrets.DEV_SERVER_PASSWORD }}
             command: |
-              cd /root/api &&
-              git checkout dev &&
-              git pull &&
-              
-              rm -f .env &&
-              touch .env &&
-              
-              echo "DJANGO_SECRET_KEY=${{ secrets.DEV_DJANGO_SECRET_KEY }}" >> .env &&
-              
-              echo "DATABASE_NAME=${{ secrets.DEV_DATABASE_NAME }}" >> .env &&
-              echo "DATABASE_PASSWORD=${{ secrets.DEV_DATABASE_PASSWORD }}" >> .env &&
-              echo "DATABASE_USER=${{ secrets.DEV_DATABASE_USER }}" >> .env &&
-              echo "DATABASE_HOST=${{ secrets.DEV_DATABASE_HOST }}" >> .env &&
-              echo "DATABASE_PORT=${{ secrets.DEV_DATABASE_PORT }}" >> .env &&
-              
+              set -eu
 
-              echo "SELECTEL_ACCOUNT_ID=${{ secrets.SELECTEL_ACCOUNT_ID }}" >> .env &&
-              echo "SELECTEL_CONTAINER_NAME=${{ secrets.SELECTEL_CONTAINER_NAME }}" >> .env &&
-              echo "SELECTEL_CONTAINER_PASSWORD=${{ secrets.SELECTEL_CONTAINER_PASSWORD }}" >> .env &&
-              echo "SELECTEL_CONTAINER_USERNAME=${{ secrets.SELECTEL_CONTAINER_USERNAME }}" >> .env &&
-              
-              echo "EMAIL_USER=${{ secrets.EMAIL_USER }}" >> .env &&
-              echo "UNISENDER_GO_API_KEY=${{ secrets.UNISENDER_GO_API_KEY }}" >> .env &&
-              
+              cd /root/api
+              git fetch --all --tags --prune
+              git branch -r --contains "${{ github.sha }}" | grep -q 'origin/dev'
+              git checkout --detach "${{ github.sha }}"
+              git rev-parse HEAD
+
+              export IMAGE_TAG="${{ github.sha }}"
+
+              rm -f .env
+              touch .env
+
+              echo "DJANGO_SECRET_KEY=${{ secrets.DEV_DJANGO_SECRET_KEY }}" >> .env
+
+              echo "DATABASE_NAME=${{ secrets.DEV_DATABASE_NAME }}" >> .env
+              echo "DATABASE_PASSWORD=${{ secrets.DEV_DATABASE_PASSWORD }}" >> .env
+              echo "DATABASE_USER=${{ secrets.DEV_DATABASE_USER }}" >> .env
+              echo "DATABASE_HOST=${{ secrets.DEV_DATABASE_HOST }}" >> .env
+              echo "DATABASE_PORT=${{ secrets.DEV_DATABASE_PORT }}" >> .env
+
+              echo "SELECTEL_ACCOUNT_ID=${{ secrets.SELECTEL_ACCOUNT_ID }}" >> .env
+              echo "SELECTEL_CONTAINER_NAME=${{ secrets.SELECTEL_CONTAINER_NAME }}" >> .env
+              echo "SELECTEL_CONTAINER_PASSWORD=${{ secrets.SELECTEL_CONTAINER_PASSWORD }}" >> .env
+              echo "SELECTEL_CONTAINER_USERNAME=${{ secrets.SELECTEL_CONTAINER_USERNAME }}" >> .env
+
+              echo "EMAIL_USER=${{ secrets.EMAIL_USER }}" >> .env
+              echo "UNISENDER_GO_API_KEY=${{ secrets.UNISENDER_GO_API_KEY }}" >> .env
+
+              chmod 600 .env
+
+              docker compose -f docker-compose.dev-ci.yml config >/dev/null
               docker compose -f docker-compose.dev-ci.yml up -d --build --force-recreate --remove-orphans &&
 
               install -d /etc/nginx/procollab/includes &&

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -4,6 +4,15 @@ on:
   release:
     types: [ published ]
   workflow_dispatch:
+    inputs:
+      image_tag:
+        description: Docker image tag to build and deploy
+        required: true
+        type: string
+      deploy_ref:
+        description: Git ref or tag to checkout on the server
+        required: true
+        type: string
 
 jobs:
   test:
@@ -49,9 +58,38 @@ jobs:
     name: Build Image
     runs-on: ubuntu-latest
     needs: [ test ]
+    outputs:
+      image_tag: ${{ steps.vars.outputs.image_tag }}
+      deploy_ref: ${{ steps.vars.outputs.deploy_ref }}
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.deploy_ref }}
+
+      - name: Resolve image tag
+        id: vars
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            image_tag='${{ github.event.release.tag_name }}'
+            deploy_ref='${{ github.event.release.tag_name }}'
+          else
+            image_tag='${{ github.event.inputs.image_tag }}'
+            deploy_ref='${{ github.event.inputs.deploy_ref }}'
+          fi
+
+          if [ -z "$image_tag" ]; then
+            echo "IMAGE_TAG is empty" >&2
+            exit 1
+          fi
+
+          if [ -z "$deploy_ref" ]; then
+            echo "DEPLOY_REF is empty" >&2
+            exit 1
+          fi
+
+          echo "image_tag=$image_tag" >> "$GITHUB_OUTPUT"
+          echo "deploy_ref=$deploy_ref" >> "$GITHUB_OUTPUT"
 
       - name: "Set up QEMU"
         uses: docker/setup-qemu-action@v3
@@ -71,11 +109,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/procollab-github/api
-          flavor: latest=true
           tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
+            type=raw,value=${{ steps.vars.outputs.image_tag }}
       - name: Build and push container
         uses: docker/build-push-action@v5
         with:
@@ -98,28 +133,69 @@ jobs:
             username: ${{ secrets.SERVER_USER }}
             password: ${{ secrets.SERVER_PASSWORD }}
             command: |
-              cd /home/app/procollab-backend &&
-              docker container prune -f &&
-              docker image prune -a -f &&
-              docker compose -f docker-compose.prod-ci.yml -p prod pull &&
-              
-              rm -f .env &&
-              touch .env &&
-              
-              echo "DJANGO_SECRET_KEY=${{ secrets.DJANGO_SECRET_KEY }}" >> .env &&
-              
-              echo "DATABASE_NAME=${{ secrets.DATABASE_NAME }}" >> .env &&
-              echo "DATABASE_PASSWORD=${{ secrets.DATABASE_PASSWORD }}" >> .env &&
-              echo "DATABASE_USER=${{ secrets.DATABASE_USER }}" >> .env &&
-              echo "DATABASE_HOST=${{ secrets.DATABASE_HOST }}" >> .env &&
-              echo "DATABASE_PORT=${{ secrets.DATABASE_PORT }}" >> .env &&
-              
-              echo "SELECTEL_ACCOUNT_ID=${{ secrets.SELECTEL_ACCOUNT_ID }}" >> .env &&
-              echo "SELECTEL_CONTAINER_NAME=${{ secrets.SELECTEL_CONTAINER_NAME }}" >> .env &&
-              echo "SELECTEL_CONTAINER_PASSWORD=${{ secrets.SELECTEL_CONTAINER_PASSWORD }}" >> .env &&
-              echo "SELECTEL_CONTAINER_USERNAME=${{ secrets.SELECTEL_CONTAINER_USERNAME }}" >> .env &&
+              set -eu
 
-              echo "EMAIL_USER=${{ secrets.EMAIL_USER }}" >> .env &&
-              echo "UNISENDER_GO_API_KEY=${{ secrets.UNISENDER_GO_API_KEY }}" >> .env &&
-              
-              docker compose -f docker-compose.prod-ci.yml -p prod up -d
+              export IMAGE_TAG="${{ needs.build.outputs.image_tag }}"
+              export DEPLOY_REF="${{ needs.build.outputs.deploy_ref }}"
+              echo "Deploying IMAGE_TAG=${IMAGE_TAG} from DEPLOY_REF=${DEPLOY_REF}"
+
+              if [ "$(id -un)" = "app" ]; then
+                git -C /home/app/procollab-backend fetch --all --tags --prune
+                git -C /home/app/procollab-backend checkout --detach "${DEPLOY_REF}"
+                git -C /home/app/procollab-backend rev-parse HEAD
+              else
+                sudo -u app git -C /home/app/procollab-backend fetch --all --tags --prune
+                sudo -u app git -C /home/app/procollab-backend checkout --detach "${DEPLOY_REF}"
+                sudo -u app git -C /home/app/procollab-backend rev-parse HEAD
+              fi
+
+              cd /home/app/procollab-backend
+              docker container prune -f
+              docker image prune -a -f
+              docker compose -f docker-compose.prod-ci.yml -p prod pull
+
+              rm -f .env
+              touch .env
+
+              echo "DJANGO_SECRET_KEY=${{ secrets.DJANGO_SECRET_KEY }}" >> .env
+
+              echo "DATABASE_NAME=${{ secrets.DATABASE_NAME }}" >> .env
+              echo "DATABASE_PASSWORD=${{ secrets.DATABASE_PASSWORD }}" >> .env
+              echo "DATABASE_USER=${{ secrets.DATABASE_USER }}" >> .env
+              echo "DATABASE_HOST=${{ secrets.DATABASE_HOST }}" >> .env
+              echo "DATABASE_PORT=${{ secrets.DATABASE_PORT }}" >> .env
+
+              echo "SELECTEL_ACCOUNT_ID=${{ secrets.SELECTEL_ACCOUNT_ID }}" >> .env
+              echo "SELECTEL_CONTAINER_NAME=${{ secrets.SELECTEL_CONTAINER_NAME }}" >> .env
+              echo "SELECTEL_CONTAINER_PASSWORD=${{ secrets.SELECTEL_CONTAINER_PASSWORD }}" >> .env
+              echo "SELECTEL_CONTAINER_USERNAME=${{ secrets.SELECTEL_CONTAINER_USERNAME }}" >> .env
+
+              echo "EMAIL_USER=${{ secrets.EMAIL_USER }}" >> .env
+              echo "UNISENDER_GO_API_KEY=${{ secrets.UNISENDER_GO_API_KEY }}" >> .env
+
+              chmod 600 .env
+              docker compose -f docker-compose.prod-ci.yml -p prod config >/dev/null
+
+              docker compose -f docker-compose.prod-ci.yml -p prod up -d --remove-orphans
+              if [ "$(id -u)" -eq 0 ]; then
+                nginx -t
+                systemctl reload nginx
+              else
+                sudo nginx -t
+                sudo systemctl reload nginx
+              fi
+
+              for attempt in $(seq 1 24); do
+                root_status="$(curl -k -s -o /dev/null -w '%{http_code}' https://api.procollab.ru/ || true)"
+                admin_status="$(curl -k -s -o /dev/null -w '%{http_code}' https://api.procollab.ru/admin/login/ || true)"
+
+                if [ "$root_status" = "401" ] && [ "$admin_status" = "200" ]; then
+                  echo "Smoke check passed on attempt ${attempt}"
+                  exit 0
+                fi
+
+                sleep 5
+              done
+
+              echo "Smoke check failed: /=${root_status} /admin/login/=${admin_status}"
+              exit 1

--- a/deploy/nginx/host/prod/api.procollab.ru
+++ b/deploy/nginx/host/prod/api.procollab.ru
@@ -1,0 +1,32 @@
+server {
+    listen 80;
+    listen [::]:80;
+    server_name api.procollab.ru;
+    server_tokens off;
+
+    location ^~ /.well-known/acme-challenge/ {
+        root /var/www/html;
+        default_type "text/plain";
+        try_files $uri =404;
+    }
+
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name api.procollab.ru;
+    server_tokens off;
+
+    ssl_certificate     /etc/letsencrypt/live/api.procollab.ru-0001/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/api.procollab.ru-0001/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    client_max_body_size 100M;
+
+    location / {
+        include /etc/nginx/procollab/includes/proxy_app.inc;
+    }
+}

--- a/docker-compose.dev-ci.yml
+++ b/docker-compose.dev-ci.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile
-    image: ghcr.io/procollab-github/api:latest
+    image: procollab-dev-api:${IMAGE_TAG:-dev}
     restart: unless-stopped
     volumes:
       - ./log:/procollab/log
@@ -28,9 +28,7 @@ services:
   celerys:
     container_name: api_celery
     restart: always
-    build:
-      context: .
-      dockerfile: ./Dockerfile
+    image: procollab-dev-api:${IMAGE_TAG:-dev}
     env_file:
       - .env
     command: bash ./scripts/celery.sh
@@ -39,6 +37,6 @@ services:
       #      - db
       - web
     volumes:
-      - .:/procollab
+      - ./log:/procollab/log
 volumes:
   redis-data:

--- a/docker-compose.prod-ci.yml
+++ b/docker-compose.prod-ci.yml
@@ -2,10 +2,7 @@ version: '3.9'
 
 services:
   web:
-    build:
-      context: .
-      dockerfile: ./Dockerfile
-    image: ghcr.io/procollab-github/api:latest
+    image: ghcr.io/procollab-github/api:${IMAGE_TAG:?IMAGE_TAG is required}
     restart: unless-stopped
     volumes:
       - ./log:/procollab/log
@@ -13,60 +10,8 @@ services:
       - .env
     environment:
       HOST: 0.0.0.0
-    expose:
-      - 8000
-      
-  # web:
-  #   image: ghcr.io/procollab-github/api:latest
-  #   restart: unless-stopped
-  #   volumes:
-  #     - log:/procollab/log
-  #   env_file:
-  #     - .env
-  #   environment:
-  #     HOST: 0.0.0.0
-  #   expose:
-  #     - 8000
-  grafana:
-    image: grafana/grafana:latest
-    restart: unless-stopped
-    expose:
-      - 3000
-    volumes:
-      - grafana-data:/var/lib/grafana
-      - grafana-configs:/etc/grafana
-    environment:
-      - GF_SERVER_ROOT_URL=%(protocol)s://%(domain)s:%(http_port)s/grafana
-      - GF_SERVER_SERVE_FROM_SUB_PATH=true
-  prometheus:
-    image: prom/prometheus:v2.36.0
-    restart: unless-stopped
-    expose:
-      - 9090
-    volumes:
-      - prom-data:/prometheus
-      - prom-configs:/etc/prometheus
-  node-exporter:
-    image: prom/node-exporter:v1.3.1
-    restart: unless-stopped
-    expose:
-      - 9100
-    volumes:
-      - /proc:/host/proc:ro
-      - /sys:/host/sys:ro
-      - /:/rootfs:ro
-    command:
-      - '--path.procfs=/host/proc'
-      - '--path.sysfs=/host/sys'
-      - '--collector.filesystem.mount-points-exclude'
-      - '^/(sys|proc|dev|host|etc|rootfs/var/lib/docker/containers|rootfs/var/lib/docker/overlay2|rootfs/run/docker/netns|rootfs/var/lib/docker/aufs)($$|/)'
-  nginx:
-    build: ./nginx
-    restart: unless-stopped
-    depends_on:
-      - web
     ports:
-      - 8000:80
+      - "127.0.0.1:8000:8000"
   redis:
     image: redis:latest
     restart: unless-stopped
@@ -79,9 +24,7 @@ services:
   celerys:
     container_name: api_celery
     restart: always
-    build:
-      context: .
-      dockerfile: ./Dockerfile
+    image: ghcr.io/procollab-github/api:${IMAGE_TAG:?IMAGE_TAG is required}
     env_file:
       - .env
     command: bash ./scripts/celery.sh
@@ -90,12 +33,7 @@ services:
 #      - db
       - web
     volumes:
-      - .:/procollab
+      - ./log:/procollab/log
 
 volumes:
-  grafana-data:
-  grafana-configs:
-  prom-data:
-  prom-configs:
-  log:
   redis-data:

--- a/scripts/celery.sh
+++ b/scripts/celery.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
-cd apps
-celery -A procollab worker --beat --loglevel=debug
+set -eu
+
+exec celery -A procollab worker --beat --loglevel=debug


### PR DESCRIPTION
# Подготовка dev/prod deploy path к релизному переключению со старой схемы на новую 

## Описание изменений

Подготовлен инфраструктурный change-set для следующего этапа релизной подготовки `prod` и выровнена схема деплоя между `dev` и `prod`.

Что изменено:
- `Deploy Dev` сделан более воспроизводимым:
  - сервер теперь checkout-ит конкретный commit, который запустил workflow, а не текущую вершину `origin/dev`
  - `web` и `celery` на `dev` теперь должны работать из одного локально собранного image
- `Release Prod` подготовлен к детерминированному релизу:
  - build и deploy теперь используют один и тот же `image_tag` / `deploy_ref`
  - убран fallback на `latest` для `prod` runtime
  - добавлен `docker compose ... config`
  - deploy теперь использует `--remove-orphans`
  - добавлены проверка и reload host `nginx`
  - добавлен post-deploy smoke-check
- `prod` compose подготовлен к host-only ingress:
  - удалён container `nginx` из `docker-compose.prod-ci.yml`
  - `web` публикуется только на `127.0.0.1:8000`
  - `celery` переведён на тот же image, что и `web`
- исправлен startup script `celery`:
  - удалён legacy `cd apps`
  - запуск приведён к корректной форме через `exec`
- добавлен repo-managed host `nginx` конфиг для `api.procollab.ru` как source of truth для будущего one-time cutover на `prod`

Важно:
- это подготовка релизного пути, а не полный `prod` переход со старой схемы на новую 
- необходимы ручные шаги для первого перехода `prod` на host-only ingress 
- `DATABASE_*` в рамках этих изменений не меняются (были вопросы с test-bd)
- `api.skills.procollab.ru`, `skills.procollab.ru` и `metabase` в scope не входят
