### PR TITLE
Prod release hardening

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -83,8 +83,28 @@ jobs:
                 exit 1
               fi &&
 
-              celery_status="$(docker inspect -f '{{.State.Status}}' api_celery 2>/dev/null || true)" &&
+              celery_status="" &&
+              celery_ping="" &&
+              for attempt in $(seq 1 24); do
+                celery_status="$(docker inspect -f '{{.State.Status}}' api_celery 2>/dev/null || true)" &&
+                if [ "$celery_status" = "running" ]; then
+                  celery_ping="$(docker compose -f docker-compose.dev-ci.yml exec -T celerys sh -lc 'celery -A procollab inspect ping -d \"celery@$(hostname)\"' 2>&1 || true)" &&
+                  printf '%s\n' "$celery_ping" &&
+                  if printf '%s\n' "$celery_ping" | grep -q 'pong'; then
+                    echo "Celery check passed on attempt ${attempt}" &&
+                    break
+                  fi
+                fi &&
+
+                sleep 5
+              done &&
+
               if [ "$celery_status" != "running" ]; then
                 echo "Celery container is not running: ${celery_status}" >&2 &&
                 exit 1
-              fi
+              fi &&
+
+              printf '%s\n' "$celery_ping" | grep -q 'pong' || {
+                echo "Celery ping failed" >&2
+                exit 1
+              }

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -210,8 +210,28 @@ jobs:
                 exit 1
               fi
 
-              celery_status="$(docker inspect -f '{{.State.Status}}' api_celery 2>/dev/null || true)"
+              celery_status=""
+              celery_ping=""
+              for attempt in $(seq 1 24); do
+                celery_status="$(docker inspect -f '{{.State.Status}}' api_celery 2>/dev/null || true)"
+                if [ "$celery_status" = "running" ]; then
+                  celery_ping="$(docker compose -f docker-compose.prod-ci.yml -p prod exec -T celerys sh -lc 'celery -A procollab inspect ping -d \"celery@$(hostname)\"' 2>&1 || true)"
+                  printf '%s\n' "$celery_ping"
+                  if printf '%s\n' "$celery_ping" | grep -q 'pong'; then
+                    echo "Celery check passed on attempt ${attempt}"
+                    break
+                  fi
+                fi
+
+                sleep 5
+              done
+
               if [ "$celery_status" != "running" ]; then
                 echo "Celery container is not running: ${celery_status}" >&2
                 exit 1
               fi
+
+              printf '%s\n' "$celery_ping" | grep -q 'pong' || {
+                echo "Celery ping failed" >&2
+                exit 1
+              }

--- a/docker-compose.dev-ci.yml
+++ b/docker-compose.dev-ci.yml
@@ -17,7 +17,7 @@ services:
       - "127.0.0.1:8000:8000" 
 
   redis:
-    image: redis:7.2.5
+    image: redis:latest
     restart: unless-stopped
     expose:
       - 6379

--- a/docker-compose.prod-ci.yml
+++ b/docker-compose.prod-ci.yml
@@ -13,7 +13,7 @@ services:
     ports:
       - "127.0.0.1:8000:8000"
   redis:
-    image: redis:7.2.5
+    image: redis:latest
     restart: unless-stopped
     expose:
       - 6379


### PR DESCRIPTION
# Скорректированы post-deploy проверки и Redis image

## Описание изменений
Что изменено:
- в `dev` и `prod` возвращена blocking-проверка `celery` после деплоя:
  - проверка статуса контейнера `api_celery`
  - `celery inspect ping` с retry loop
- в актуальных `dev`/`prod` compose-файлах Redis временно возвращён к прежнему image:
  - это нужно для совместимости с существующим Redis volume и текущим `dump.rdb`
