### PR TITLE
Зафиксирована Redis 8.6.2 и смягчён автодеплой

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -52,7 +52,7 @@ jobs:
               docker compose -f docker-compose.dev-ci.yml config >/dev/null
               docker compose -f docker-compose.dev-ci.yml build web &&
               docker compose -f docker-compose.dev-ci.yml run --rm web python manage.py migrate &&
-              docker compose -f docker-compose.dev-ci.yml up -d --force-recreate --remove-orphans &&
+              docker compose -f docker-compose.dev-ci.yml up -d --force-recreate &&
 
               install -d /etc/nginx/procollab/includes &&
               install -m 644 deploy/nginx/host/includes/proxy_app.inc /etc/nginx/procollab/includes/proxy_app.inc &&

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -181,10 +181,10 @@ jobs:
 
               chmod 600 .env
               docker compose -f docker-compose.prod-ci.yml -p prod config >/dev/null
-              docker compose -f docker-compose.prod-ci.yml -p prod pull
+              docker compose -f docker-compose.prod-ci.yml -p prod pull web celerys
 
               docker compose -f docker-compose.prod-ci.yml -p prod run --rm web python manage.py migrate
-              docker compose -f docker-compose.prod-ci.yml -p prod up -d --remove-orphans
+              docker compose -f docker-compose.prod-ci.yml -p prod up -d
               if [ "$(id -u)" -eq 0 ]; then
                 nginx -t
                 systemctl reload nginx

--- a/docker-compose.dev-ci.yml
+++ b/docker-compose.dev-ci.yml
@@ -17,7 +17,7 @@ services:
       - "127.0.0.1:8000:8000" 
 
   redis:
-    image: redis:latest
+    image: redis:8.6.2
     restart: unless-stopped
     expose:
       - 6379

--- a/docker-compose.prod-ci.yml
+++ b/docker-compose.prod-ci.yml
@@ -13,7 +13,7 @@ services:
     ports:
       - "127.0.0.1:8000:8000"
   redis:
-    image: redis:latest
+    image: redis:8.6.2
     restart: unless-stopped
     expose:
       - 6379

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
   redis:
     profiles: ["legacy"]
     container_name: redis
-    image: redis:latest
+    image: redis:8.6.2
     expose:
       - 6379
     volumes:


### PR DESCRIPTION
# Что изменено

Смягчён автодеплой `dev`/`prod` и зафиксирована версия Redis.

Изменения:
- в `docker-compose.dev-ci.yml`, `docker-compose.prod-ci.yml` и legacy `docker-compose.yml` Redis переведён с `redis:latest` на `redis:8.6.2`
- в `release-ci.yml` prod-deploy больше не делает полный `docker compose pull`, а тянет только `web` и `celerys`
- в `release-ci.yml` убран `--remove-orphans` из `docker compose up -d`
- в `dev-ci.yml` убран `--remove-orphans` из deploy шага