### PR TITLE
Исправлена маршрутизация frontend на dev

### DIFF
--- a/deploy/nginx/host/dev/dev.procollab.ru
+++ b/deploy/nginx/host/dev/dev.procollab.ru
@@ -18,11 +18,33 @@ server {
     listen 443 ssl;
     server_name dev.procollab.ru;
     server_tokens off;
+    root /home/front/app;
+    index index.html;
 
     ssl_certificate     /etc/letsencrypt/live/dev.procollab.ru-0001/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/dev.procollab.ru-0001/privkey.pem;
 
-    location / {
+    location ~ ^/(admin|api-auth|files|industries|news|projects|vacancies|core|invites|auth|chats|events|programs|courses|rate-project|feed|api|anymail|ws)(/|$) {
         include /etc/nginx/procollab/includes/proxy_app.inc;
+    }
+
+    location ~ ^/(swagger(\.json|\.yaml)?|swagger/|redoc/?)$ {
+        include /etc/nginx/procollab/includes/proxy_app.inc;
+    }
+
+    location ^~ /static/admin/ {
+        include /etc/nginx/procollab/includes/proxy_app.inc;
+    }
+
+    location ^~ /static/drf-yasg/ {
+        include /etc/nginx/procollab/includes/proxy_app.inc;
+    }
+
+    location ^~ /static/rest_framework/ {
+        include /etc/nginx/procollab/includes/proxy_app.inc;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
     }
 }


### PR DESCRIPTION
# Что изменено

Исправлена маршрутизация `dev.procollab.ru` в host nginx.

Теперь:
- frontend отдаётся из `/home/front/app`
- SPA routes вроде `/projects`, `/projects-rating`, `/profile` возвращают `index.html`
- backend остаётся доступен через API/admin/ws-префиксы
- Django admin/static swagger/rest_framework paths продолжают проксироваться в backend