### PR TITLE
Усилена проверка dev deploy pipeline

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -53,6 +53,23 @@ jobs:
               docker compose -f docker-compose.dev-ci.yml build web &&
               docker compose -f docker-compose.dev-ci.yml run --rm web python manage.py migrate &&
               docker compose -f docker-compose.dev-ci.yml up -d --force-recreate &&
+              expected_image="procollab-dev-api:${IMAGE_TAG}" &&
+              for service in web celerys; do
+                container="$(docker compose -f docker-compose.dev-ci.yml ps -q "$service")"
+                if [ -z "$container" ]; then
+                  echo "Service ${service} has no running container" >&2
+                  docker compose -f docker-compose.dev-ci.yml ps >&2 || true
+                  exit 1
+                fi
+
+                actual_image="$(docker inspect -f '{{.Config.Image}}' "$container")"
+                echo "Service ${service}: container=${container} image=${actual_image}"
+                if [ "$actual_image" != "$expected_image" ]; then
+                  echo "Service ${service} uses unexpected image: ${actual_image}, expected ${expected_image}" >&2
+                  docker compose -f docker-compose.dev-ci.yml ps >&2 || true
+                  exit 1
+                fi
+              done &&
 
               install -d /etc/nginx/procollab/includes &&
               install -m 644 deploy/nginx/host/includes/proxy_app.inc /etc/nginx/procollab/includes/proxy_app.inc &&
@@ -83,28 +100,37 @@ jobs:
                 exit 1
               fi &&
 
-              celery_status="" &&
-              celery_ping="" &&
-              for attempt in $(seq 1 24); do
-                celery_status="$(docker inspect -f '{{.State.Status}}' api_celery 2>/dev/null || true)" &&
+              docker compose -f docker-compose.dev-ci.yml ps
+
+              celery_status=""
+              celery_ping=""
+              celery_container=""
+              for attempt in $(seq 1 12); do
+                celery_container="$(docker compose -f docker-compose.dev-ci.yml ps -q celerys 2>/dev/null || true)"
+                if [ -n "$celery_container" ]; then
+                  celery_status="$(docker inspect -f '{{.State.Status}}' "$celery_container" 2>/dev/null || true)"
+                else
+                  celery_status="missing"
+                fi
+
+                echo "Celery check attempt ${attempt}: container=${celery_container:-missing} status=${celery_status}"
                 if [ "$celery_status" = "running" ]; then
-                  celery_ping="$(docker compose -f docker-compose.dev-ci.yml exec -T celerys sh -lc 'celery -A procollab inspect ping --timeout=10' 2>&1 || true)" &&
-                  printf '%s\n' "$celery_ping" &&
+                  celery_ping="$(docker compose -f docker-compose.dev-ci.yml exec -T celerys sh -lc 'celery -A procollab inspect ping --timeout=15' 2>&1 || true)"
+                  printf '%s\n' "$celery_ping"
                   if printf '%s\n' "$celery_ping" | grep -q 'pong'; then
-                    echo "Celery check passed on attempt ${attempt}" &&
+                    echo "Celery check passed on attempt ${attempt}"
                     break
                   fi
-                fi &&
+                fi
 
                 sleep 5
-              done &&
+              done
 
-              if [ "$celery_status" != "running" ]; then
-                echo "Celery container is not running: ${celery_status}" >&2 &&
+              if [ "$celery_status" != "running" ] || ! printf '%s\n' "$celery_ping" | grep -q 'pong'; then
+                echo "Celery check failed: status=${celery_status}" >&2
+                docker compose -f docker-compose.dev-ci.yml ps >&2 || true
+                docker compose -f docker-compose.dev-ci.yml logs --tail=200 celerys >&2 || true
+                docker compose -f docker-compose.dev-ci.yml logs --tail=100 redis >&2 || true
+                docker compose -f docker-compose.dev-ci.yml logs --tail=100 web >&2 || true
                 exit 1
-              fi &&
-
-              printf '%s\n' "$celery_ping" | grep -q 'pong' || {
-                echo "Celery ping failed" >&2
-                exit 1
-              }
+              fi


### PR DESCRIPTION
# Что изменено

- Усилен dev deploy pipeline в `.github/workflows/dev-ci.yml`.
- После `docker compose up` добавлена проверка, что сервисы `web` и `celerys` запущены из ожидаемого image текущего commit.
- Проверка Celery переведена с глобального имени контейнера `api_celery` на compose service `celerys`.
- Celery health-check ограничен примерно 4 минутами: 12 попыток, `celery inspect ping --timeout=15`.
- При ошибке Celery-check теперь выводятся:
  - `docker compose ps`;
  - последние логи `celerys`;
  - последние логи `redis`;
  - последние логи `web`.

Цель изменений: исключить ситуацию, когда репозиторий на dev обновился, но контейнеры продолжают работать на старом image, и сделать падения deploy pipeline диагностируемыми.
