### PR TITLE
fix react dev deploy stdin handling

### DIFF
--- a/docs/backend-react-dev-autodeploy.md
+++ b/docs/backend-react-dev-autodeploy.md
@@ -88,8 +88,10 @@ containers проверяется наличие точных сервисов `
 2. Проверка repository, origin, git state и stale deploy.
 3. Сохранение предыдущих SHA, container IDs, image IDs и image references.
 4. Сборка новых `web` и `celerys` images без остановки текущего backend.
-5. `python manage.py check` во временном container нового `web` image.
-6. `python manage.py migrate --noinput` с существующим React-dev `.env`.
+5. `python manage.py check` во временном container нового `web` image без TTY
+   и без доступа к stdin deploy-скрипта.
+6. `python manage.py migrate --noinput` с существующим React-dev `.env`, также без TTY
+   и с stdin, подключенным к `/dev/null`.
 7. Пересоздание только `web` и `celerys` через `up -d --no-deps --force-recreate`.
 8. Ожидание running state с ограниченным timeout.
 9. Публичный HTTPS health-check.

--- a/scripts/deploy_react_dev.sh
+++ b/scripts/deploy_react_dev.sh
@@ -487,7 +487,7 @@ log "Django system check на новом web image."
 "${COMPOSE_CMD[@]}" run \
     --rm \
     --no-deps \
-    --no-TTY \
+    --no-tty \
     web python manage.py check </dev/null
 
 MIGRATION_STARTED=true
@@ -495,7 +495,7 @@ log "Применение миграций React-dev на новом web image."
 "${COMPOSE_CMD[@]}" run \
     --rm \
     --no-deps \
-    --no-TTY \
+    --no-tty \
     web python manage.py migrate --noinput </dev/null
 MIGRATION_COMPLETED=true
 

--- a/scripts/deploy_react_dev.sh
+++ b/scripts/deploy_react_dev.sh
@@ -484,14 +484,19 @@ fi
 HEALTH_JSON_IMAGE_ID="$new_web_image_id"
 
 log "Django system check на новом web image."
-"${COMPOSE_CMD[@]}" run --rm --no-deps web python manage.py check
+"${COMPOSE_CMD[@]}" run \
+    --rm \
+    --no-deps \
+    --no-TTY \
+    web python manage.py check </dev/null
 
 MIGRATION_STARTED=true
 log "Применение миграций React-dev на новом web image."
 "${COMPOSE_CMD[@]}" run \
     --rm \
     --no-deps \
-    web python manage.py migrate --noinput
+    --no-TTY \
+    web python manage.py migrate --noinput </dev/null
 MIGRATION_COMPLETED=true
 
 CONTAINERS_MAY_HAVE_CHANGED=true


### PR DESCRIPTION
## Что исправлено

- Временные `docker compose run` containers запускаются без TTY.
- stdin для Django system check и миграций подключён к `/dev/null`.
- Deploy script больше не может быть прочитан временным container через stdin.
- Документация обновлена с описанием non-interactive запуска.

## Причина

Workflow передаёт deploy script удалённому `bash` через stdin:

```text
ssh ... "bash -s ..." < scripts/deploy_react_dev.sh