### PR TITLE
use short no tty option for react dev deploy

### DIFF
--- a/scripts/deploy_react_dev.sh
+++ b/scripts/deploy_react_dev.sh
@@ -487,7 +487,7 @@ log "Django system check на новом web image."
 "${COMPOSE_CMD[@]}" run \
     --rm \
     --no-deps \
-    --no-tty \
+    -T \
     web python manage.py check </dev/null
 
 MIGRATION_STARTED=true
@@ -495,7 +495,7 @@ log "Применение миграций React-dev на новом web image."
 "${COMPOSE_CMD[@]}" run \
     --rm \
     --no-deps \
-    --no-tty \
+    -T \
     web python manage.py migrate --noinput </dev/null
 MIGRATION_COMPLETED=true
 


### PR DESCRIPTION
## Что исправлено

- Неподдерживаемый текущей версией Compose флаг `--no-tty` заменён на совместимый короткий вариант `-T`.
- stdin временных containers по-прежнему подключён к `/dev/null`.
- Изменён только deploy script.

## Причина

Первый запуск после PR #677 безопасно остановился на Django system check:

```text
unknown flag: --no-tty
```

После ошибки:

- миграции не запускались;
- `web` и `celerys` не пересоздавались;
- rollback завершился успешно;
- production и `/root/api` не затрагивались.

## Проверка

- `bash -n scripts/deploy_react_dev.sh` — успешно.
- `git diff --check` — успешно.
- Изменён только `scripts/deploy_react_dev.sh`.
- Post-merge `Backend PostgreSQL CI` — успешно.
- `Backend React-dev deploy #4` — успешно.
- Подтверждены сборка image, Django system check, миграции, пересоздание `web` и `celerys`, running state и публичный HTTPS health-check.
- Production и старый backend `/root/api` не затрагивались.

## Roadmap

Roadmap-IDs: DEV-075
Roadmap-Complete: DEV-075