### PR TITLE
Allow manual CI to trigger React-dev deploy

### DIFF
--- a/.github/workflows/backend-react-dev-deploy.yml
+++ b/.github/workflows/backend-react-dev-deploy.yml
@@ -24,7 +24,10 @@ jobs:
     if: >-
       ${{
         github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.event == 'push' &&
+        (
+          github.event.workflow_run.event == 'push' ||
+          github.event.workflow_run.event == 'workflow_dispatch'
+        ) &&
         github.event.workflow_run.head_branch == 'master' &&
         github.event.workflow_run.head_repository.full_name == github.repository &&
         github.event.workflow_run.head_sha != ''


### PR DESCRIPTION
## Что изменено

- React-dev deploy теперь принимает успешный `Backend PostgreSQL CI`, запущенный вручную через `workflow_dispatch`, наряду с обычным `push` в `master`.
- Остальные проверки источника сохранены: ветка `master`, тот же repository, успешный результат и валидный commit SHA.

## Причина

После merge PR №684 GitHub не создал push-run `Backend PostgreSQL CI`, хотя workflow настроен на `push` в `master`. Из-за этого зависимый deploy не мог стартовать. Ранее ручной запуск CI также приводил бы к skipped deploy, потому что deploy принимал только upstream event `push`.

## Проверки

- Ветка создана от merge-коммита PR №684 `bc872a2a01301adf387b13fbf05807693403027a`.
- Один commit, изменён один workflow-файл.
- Условия безопасности для `master`, repository, conclusion и SHA не ослаблены.

## После merge

1. Открыть `Actions` → `Backend PostgreSQL CI`.
2. Нажать `Run workflow`, выбрать `master`.
3. После зелёного CI автоматически запустится `Backend React-dev deploy` по новой схеме с prebuilt image.

Production и бизнес-код не изменяются.

Roadmap-IDs: DEV-075
Roadmap-Partial: DEV-075